### PR TITLE
Added frictionless request option to iOS

### DIFF
--- a/ios/AirFacebook/AirFacebook.h
+++ b/ios/AirFacebook/AirFacebook.h
@@ -41,6 +41,7 @@ typedef void (^FBRequestCompletionHandler)(FBRequestConnection *connection, id r
 
 @property (nonatomic, readonly) NSString *appID;
 @property (nonatomic, readonly) NSString *urlSchemeSuffix;
+@property (nonatomic, readonly) FBFrictionlessRecipientCache *friendCache;
 
 @end
 

--- a/ios/AirFacebook/AirFacebook.m
+++ b/ios/AirFacebook/AirFacebook.m
@@ -32,6 +32,7 @@ FREContext AirFBCtx = nil;
 
 @synthesize appID = _appID;
 @synthesize urlSchemeSuffix = _urlSchemeSuffix;
+@synthesize friendCache = _friendCache;
 
 static AirFacebook *sharedInstance = nil;
 
@@ -70,6 +71,7 @@ static AirFacebook *sharedInstance = nil;
     // Save parameters
     _appID = appID;
     _urlSchemeSuffix = urlSchemeSuffix;
+	_friendCache = [[FBFrictionlessRecipientCache alloc] init];
     NSMutableString *logMessage = [NSMutableString stringWithFormat:@"Initializing with application ID %@", _appID];
     if (_urlSchemeSuffix)
     {
@@ -133,6 +135,7 @@ static AirFacebook *sharedInstance = nil;
         {
             [AirFacebook log:[NSString stringWithFormat:@"Session opened with permissions: %@", [session.permissions componentsJoinedByString:@", "]]];
             [AirFacebook dispatchEvent:@"OPEN_SESSION_SUCCESS" withMessage:@"OK"];
+			[[[AirFacebook sharedInstance] friendCache] prefetchAndCacheForSession:nil];
             
         }
         else if (status == FBSessionStateClosed)
@@ -167,6 +170,7 @@ static AirFacebook *sharedInstance = nil;
         {
             [AirFacebook log:@"Session reauthorized with permissions: %@", session.permissions];
             [AirFacebook dispatchEvent:@"REAUTHORIZE_SESSION_SUCCESS" withMessage:@"OK"];
+			[[[AirFacebook sharedInstance] friendCache] prefetchAndCacheForSession:nil];
         }
     };
 }
@@ -640,7 +644,7 @@ DEFINE_ANE_FUNCTION(dialog)
                      }
                  }
              }
-             ];
+			 friendCache:[[AirFacebook sharedInstance] friendCache]];
         } else
         {
             [FBWebDialogs presentDialogModallyWithSession:nil dialog:method parameters:parameters

--- a/ios/AirFacebook/AirFacebook.m
+++ b/ios/AirFacebook/AirFacebook.m
@@ -71,7 +71,7 @@ static AirFacebook *sharedInstance = nil;
     // Save parameters
     _appID = appID;
     _urlSchemeSuffix = urlSchemeSuffix;
-	_friendCache = [[FBFrictionlessRecipientCache alloc] init];
+    _friendCache = [[FBFrictionlessRecipientCache alloc] init];
     NSMutableString *logMessage = [NSMutableString stringWithFormat:@"Initializing with application ID %@", _appID];
     if (_urlSchemeSuffix)
     {
@@ -135,7 +135,7 @@ static AirFacebook *sharedInstance = nil;
         {
             [AirFacebook log:[NSString stringWithFormat:@"Session opened with permissions: %@", [session.permissions componentsJoinedByString:@", "]]];
             [AirFacebook dispatchEvent:@"OPEN_SESSION_SUCCESS" withMessage:@"OK"];
-			[[[AirFacebook sharedInstance] friendCache] prefetchAndCacheForSession:nil];
+            [[[AirFacebook sharedInstance] friendCache] prefetchAndCacheForSession:nil];
             
         }
         else if (status == FBSessionStateClosed)
@@ -170,7 +170,7 @@ static AirFacebook *sharedInstance = nil;
         {
             [AirFacebook log:@"Session reauthorized with permissions: %@", session.permissions];
             [AirFacebook dispatchEvent:@"REAUTHORIZE_SESSION_SUCCESS" withMessage:@"OK"];
-			[[[AirFacebook sharedInstance] friendCache] prefetchAndCacheForSession:nil];
+            [[[AirFacebook sharedInstance] friendCache] prefetchAndCacheForSession:nil];
         }
     };
 }
@@ -644,7 +644,7 @@ DEFINE_ANE_FUNCTION(dialog)
                      }
                  }
              }
-			 friendCache:[[AirFacebook sharedInstance] friendCache]];
+             friendCache:[[AirFacebook sharedInstance] friendCache]];
         } else
         {
             [FBWebDialogs presentDialogModallyWithSession:nil dialog:method parameters:parameters


### PR DESCRIPTION
Frictionless request is described in more details here: https://developers.facebook.com/blog/post/569/

Testing:
1.  Send a facebook request as such: _facebook.dialog("apprequests", { title: "Test", message:"Frictionless request", to:"<facebook_id>"});
2. The facebook request dialog should appear, with the option "Don't ask again before sending requests to ... from this app". Check this option and send the request.
3. Send another request to the same recipient. The request dialog should not appear this time, but the recipient should still receive the request.
4. Send the request to another recipient. The request dialog should appear because this recipient is not in the frictionless request cache.

Notes:
1. The frictionless request list is stored on the Facebook server per user per friend per app. There isn't anyway to reset it as far as I know. So once a request has been sent frictionlessly to a friend, it will always be frictionless.

Android notes:
1. On Android, frictionless requests can be enabled without any native code changes. Just pass in the parameter "frictionless":"1", i.e.:
_facebook.dialog("apprequests", { title: "Test", message:"Frictionless request", to:"<facebook_id>", "frictionless":"1"});
