### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ On Android:
             <application>
 
                 ...
-                
-                <activity android:name="com.facebook.LoginActivity"/>
-                <activity android:name="com.freshplanet.ane.AirFacebook.LoginActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen"></activity>
-                <activity android:name="com.freshplanet.ane.AirFacebook.DialogActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen"></activity>
+                <activity android:name="com.facebook.LoginActivity" android:configChanges="keyboardHidden|orientation|screenSize"/>
+                <activity android:name="com.freshplanet.ane.AirFacebook.LoginActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen" android:configChanges="keyboardHidden|orientation|screenSize"></activity>
+                <activity android:name="com.freshplanet.ane.AirFacebook.DialogActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen" android:configChanges="keyboardHidden|orientation|screenSize"></activity>
+
                 
             </application>
 


### PR DESCRIPTION
There is a problem effected all android devices. If user dont have Facebook native app and try to login on webwiew dialog stuck on the permission screen. Even user close the screen its appears again and not go away.

Problem only show if user change oriantation on webview dialog. Because if i dont change the oriantation its works fine on my device. But some devices changes oriantation automatically and it doesnt works.

This is a android webview bug. If you dont configure your oriantation settings then activity recreated on oriantation change. I guess its effect to newly created app because android api changes. 
