### PR TITLE
Fixed an issue with the android build

### DIFF
--- a/android/src/com/freshplanet/ane/AirFacebook/AirFacebookExtension.java
+++ b/android/src/com/freshplanet/ane/AirFacebook/AirFacebookExtension.java
@@ -49,11 +49,6 @@ public class AirFacebookExtension implements FREExtension
 		if (context != null && message != null) context.dispatchStatusEventAsync("LOGGING", message);
 	}
 	
-	public static int getResourceId(String name)
-	{
-		return context != null ? context.getResourceId(name) : 0;
-	}
-	
 	public static int[] getResourceIds(String name)
 	{
 		// TODO

--- a/android/src/com/freshplanet/ane/AirFacebook/LoginActivity.java
+++ b/android/src/com/freshplanet/ane/AirFacebook/LoginActivity.java
@@ -61,7 +61,7 @@ public class LoginActivity extends Activity
 		
 		// Setup views
 		requestWindowFeature(Window.FEATURE_LEFT_ICON);
-		setContentView(_context.getResourceId("layout.com_facebook_login_activity_layout"));
+		setContentView(com.facebook.android.R.layout.com_facebook_login_activity_layout);
 		
 		// Get extra values
 		Bundle extras = this.getIntent().getExtras();

--- a/android/src/com/freshplanet/ane/AirFacebook/WebDialogActivity.java
+++ b/android/src/com/freshplanet/ane/AirFacebook/WebDialogActivity.java
@@ -64,7 +64,7 @@ public class WebDialogActivity extends Activity implements WebDialog.OnCompleteL
 		
 		// Setup views
 		requestWindowFeature(Window.FEATURE_LEFT_ICON);
-		setContentView(AirFacebookExtension.getResourceId("layout.com_facebook_login_activity_layout"));
+		setContentView(com.facebook.android.R.layout.com_facebook_login_activity_layout);
 		
 		if ( session.isOpened() )
 		{


### PR DESCRIPTION
Fixed an issue with the android build where the method "context.getResourceId" was failing on the FREContext. This caused a crash on android devices.
All layouts are now requested using the R.\* mechanism, which works when tested on AIR 16.
